### PR TITLE
Add macOS version with menu bar app, Homebrew formula, and unified CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,19 +6,17 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  build-windows:
     runs-on: windows-latest
     permissions:
-      contents: write     # required to create releases and upload assets
+      contents: write
 
     steps:
-      # 1. Check out source code
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0          # needed to count all commits for version number
+          fetch-depth: 0
 
-      # 2. Auto-generate version number based on commit count (1.0, 1.1, 1.2 ...)
       - name: Generate version number
         id: version
         shell: bash
@@ -27,7 +25,6 @@ jobs:
           echo "number=1.$((COUNT - 1))" >> $GITHUB_OUTPUT
           echo "tag=v1.$((COUNT - 1))" >> $GITHUB_OUTPUT
 
-      # 3. Set up MSVC
       - name: Set up MSBuild
         uses: microsoft/setup-msbuild@v2
 
@@ -36,7 +33,6 @@ jobs:
         with:
           arch: x64
 
-      # 4. Compile with MSVC
       - name: Build
         run: |
           cl USBAutoPlayer.cpp `
@@ -47,26 +43,119 @@ jobs:
             /SUBSYSTEM:WINDOWS `
             /OUT:USBGroove.exe
 
-      # 5. Create GitHub Release and attach the .exe automatically
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-build
+          path: USBGroove.exe
+
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
+
+  build-macos:
+    runs-on: macos-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build
+        run: |
+          swiftc macos/USBGroove.swift -o USBGroove \
+            -framework AVFoundation \
+            -framework DiskArbitration \
+            -framework AppKit \
+            -O
+
+      - name: Create .app bundle
+        run: |
+          mkdir -p USBGroove.app/Contents/MacOS
+          mkdir -p USBGroove.app/Contents/Resources
+          cp USBGroove USBGroove.app/Contents/MacOS/USBGroove
+          cat > USBGroove.app/Contents/Info.plist << 'PLIST'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>CFBundleName</key>
+              <string>USB Groove</string>
+              <key>CFBundleDisplayName</key>
+              <string>USB Groove</string>
+              <key>CFBundleIdentifier</key>
+              <string>com.michaelnoergaard.USBGroove</string>
+              <key>CFBundleVersion</key>
+              <string>1.0</string>
+              <key>CFBundleShortVersionString</key>
+              <string>1.0</string>
+              <key>CFBundleExecutable</key>
+              <string>USBGroove</string>
+              <key>CFBundlePackageType</key>
+              <string>APPL</string>
+              <key>LSMinimumSystemVersion</key>
+              <string>12.0</string>
+              <key>LSUIElement</key>
+              <true/>
+              <key>NSHighResolutionCapable</key>
+              <true/>
+          </dict>
+          </plist>
+          PLIST
+
+      - name: Create zip
+        run: |
+          ditto -c -k --keepParent USBGroove.app USBGroove-macOS.zip
+
+      - name: Upload macOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-build
+          path: USBGroove-macOS.zip
+
+  release:
+    needs: [build-windows, build-macos]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download Windows artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-build
+
+      - name: Download macOS artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-build
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.version.outputs.tag }}
-          name: USB Groove ${{ steps.version.outputs.tag }}
+          tag_name: ${{ needs.build-windows.outputs.tag }}
+          name: USB Groove ${{ needs.build-windows.outputs.tag }}
           body: |
-            ## USB Groove ${{ steps.version.outputs.tag }}
+            ## USB Groove ${{ needs.build-windows.outputs.tag }}
 
-            Self-contained Windows 11 tray app — no installation required.
+            Lightweight tray/menu bar app — no installation required.
 
-            **Just download `USBGroove.exe` and run it. Nothing to install.**
+            ### Downloads
+            | Platform | File | Install |
+            |----------|------|---------|
+            | **Windows** | `USBGroove.exe` | Just download and run |
+            | **macOS** | `USBGroove-macOS.zip` | Unzip and move to Applications |
 
             ### What it does
             - Automatically plays MP3 files from any inserted USB drive
-            - Sits silently in the system tray
-            - Right-click tray icon for controls (Pause, Next, Previous, Shuffle)
+            - Sits in the system tray (Windows) or menu bar (macOS)
+            - Controls: Pause, Next, Previous, Shuffle
 
-            ### Changes in this release
-            ${{ github.event.head_commit.message }}
-          files: USBGroove.exe
+            ### Package managers
+            - **Windows:** `winget install michaelnoergaard.USBGroove`
+            - **macOS:** `brew tap michaelnoergaard/usb-groove && brew install usb-groove`
+          files: |
+            USBGroove.exe
+            USBGroove-macOS.zip
           draft: false
           prerelease: false

--- a/README.md
+++ b/README.md
@@ -2,91 +2,110 @@
 
 ![Version](https://img.shields.io/badge/version-2.0-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
-![Platform](https://img.shields.io/badge/platform-Windows-lightgrey.svg)
+![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS-lightgrey.svg)
 
-A lightweight Windows system tray application that automatically plays MP3 files from any inserted USB flash drive. No external media player required - uses the built-in Windows MCI audio engine.
+A lightweight tray/menu bar application that automatically plays MP3 files from any inserted USB flash drive. No external media player required — uses built-in OS audio engines.
 
 ## Features
 
 - **Auto-play** - Automatically detects USB drives and starts playing MP3 files
-- **System tray app** - Runs quietly in the background with minimal footprint
+- **System tray (Windows) / Menu bar (macOS)** - Runs quietly in the background
 - **Shuffle mode** - Randomize playback order with one click
 - **Full playback controls** - Play, pause, stop, next/previous track
 - **Recursive scanning** - Finds MP3 files in all subdirectories
-- **No dependencies** - Uses only built-in Windows DLLs (winmm.dll, shell32.dll, user32.dll, gdi32.dll, kernel32.dll)
-- **Single instance** - Prevents multiple copies from running
-- **Logging** - Debug log stored in `%TEMP%\USBAutoPlayer.log`
+- **No dependencies** - Uses only built-in OS libraries
+- **Single file** - One executable, nothing to install
+- **Logging** - Debug log in `%TEMP%\USBAutoPlayer.log` (Windows) or `/tmp/USBGroove.log` (macOS)
 
 ## Download
 
-Download the latest release from [GitHub Releases](https://github.com/michael/USB-Groove/releases).
+Download the latest release from [GitHub Releases](https://github.com/michaelnoergaard/USB-Groove/releases).
+
+| Platform | File | How to run |
+|----------|------|------------|
+| **Windows** | `USBGroove.exe` | Just download and run |
+| **macOS** | `USBGroove-macOS.zip` | Unzip, move `USBGroove.app` to Applications |
+
+## Install via package manager
+
+**Windows (winget):**
+```powershell
+winget install michaelnoergaard.USBGroove
+```
+
+**macOS (Homebrew):**
+```bash
+brew tap michaelnoergaard/usb-groove
+brew install usb-groove
+```
 
 ## Usage
 
-1. Run `USBAutoPlayer.exe`
+1. Run USB Groove
 2. Insert a USB drive containing MP3 files
 3. Playback starts automatically!
 
-### Tray Icon Controls
+### Controls
 
-| Action | Result |
-|--------|--------|
-| **Right-click** | Open context menu with playback controls |
-| **Double-click** | Show current track info (or idle status) |
+**Windows:** Right-click the system tray icon. Double-click for track info.
 
-### Context Menu Options
+**macOS:** Click the music note icon in the menu bar.
 
-- **Pause/Resume** - Toggle playback
-- **Previous track** - Go to the previous song
-- **Next track** - Skip to the next song
-- **Stop** - Stop playback and clear playlist
-- **Shuffle** - Enable/disable shuffle mode (toggle)
-- **About** - View version information
-- **Exit** - Close the application
+| Control | Action |
+|---------|--------|
+| **Pause/Resume** | Toggle playback |
+| **Previous track** | Go to the previous song |
+| **Next track** | Skip to the next song |
+| **Stop** | Stop playback and clear playlist |
+| **Shuffle** | Enable/disable shuffle mode |
+| **About** | View version information |
 
-## Build Instructions
+## Build from source
 
-### Prerequisites
-
-- Windows 10/11
-- C++17 compatible compiler
-
-### MSVC (Developer Command Prompt)
+### Windows (MSVC)
 
 ```cmd
 cl USBAutoPlayer.cpp /O2 /W4 /EHsc /std:c++17 ^
     /DUNICODE /D_UNICODE /DWIN32_LEAN_AND_MEAN ^
     /link winmm.lib shell32.lib user32.lib gdi32.lib kernel32.lib ^
-    /SUBSYSTEM:WINDOWS /OUT:USBAutoPlayer.exe
+    /SUBSYSTEM:WINDOWS /OUT:USBGroove.exe
 ```
 
-### MinGW / MSYS2
+### Windows (MinGW / MSYS2)
 
 ```bash
 g++ -std=c++17 -O2 -Wall -DUNICODE -D_UNICODE -DWIN32_LEAN_AND_MEAN \
-    -o USBAutoPlayer.exe USBAutoPlayer.cpp \
+    -o USBGroove.exe USBAutoPlayer.cpp \
     -lwinmm -lshell32 -luser32 -lgdi32 -mwindows
+```
+
+### macOS
+
+```bash
+swiftc macos/USBGroove.swift -o USBGroove \
+    -framework AVFoundation \
+    -framework DiskArbitration \
+    -framework AppKit -O
 ```
 
 ## How It Works
 
-1. **Device Detection** - The application registers for Windows device change notifications to detect when new drives are mounted
+### Windows
+1. Registers for `WM_DEVICECHANGE` notifications to detect USB drives
+2. Waits ~1.8s for filesystem to mount, then scans for MP3 files
+3. Plays audio via Windows MCI (`winmm.dll`) — no external codecs needed
+4. Auto-advances to next track when current track finishes
 
-2. **Drive Validation** - When a drive is inserted, it waits ~1.8 seconds for the filesystem to mount, then validates the drive type (skips network drives and RAM disks)
+### macOS
+1. Monitors volume mounts via `NSWorkspace` notifications
+2. Identifies external/removable drives via volume resource keys
+3. Plays audio via `AVFoundation` (`AVAudioPlayer`) — no external codecs needed
+4. Auto-advances to next track when current track finishes
 
-3. **MP3 Scanning** - Recursively scans all directories on the drive for `.mp3` files
+## Distribution
 
-4. **Playback** - Uses Windows MCI (Media Control Interface) via `winmm.dll` to play audio - no external codecs or players needed
-
-5. **Auto-advance** - When a track finishes, automatically plays the next track in the playlist
-
-## Install via winget
-
-```powershell
-winget install michaelnoergaard.USBGroove
-```
-
-For details on how winget distribution works for this project, see [WINGET.md](WINGET.md).
+- **Windows winget:** See [WINGET.md](WINGET.md)
+- **macOS Homebrew:** See [homebrew/usb-groove.rb](homebrew/usb-groove.rb) for the cask formula
 
 ## License
 

--- a/homebrew/usb-groove.rb
+++ b/homebrew/usb-groove.rb
@@ -1,0 +1,23 @@
+# Homebrew Cask formula for USB Groove
+# To use: brew tap michaelnoergaard/usb-groove && brew install usb-groove
+#
+# To set up the tap, create a repo named "homebrew-usb-groove" containing:
+#   Casks/usb-groove.rb  (copy of this file with the correct sha256)
+
+cask "usb-groove" do
+  version :latest
+  sha256 :no_check
+
+  url "https://github.com/michaelnoergaard/USB-Groove/releases/latest/download/USBGroove-macOS.zip"
+  name "USB Groove"
+  desc "Menu bar app that automatically plays MP3 files from USB drives"
+  homepage "https://github.com/michaelnoergaard/USB-Groove"
+
+  depends_on macos: ">= :monterey"
+
+  app "USBGroove.app"
+
+  zap trash: [
+    "~/Library/Logs/USBGroove.log",
+  ]
+end

--- a/macos/USBGroove.swift
+++ b/macos/USBGroove.swift
@@ -1,0 +1,427 @@
+// =============================================================================
+// USBGroove.swift — macOS Menu Bar App
+//
+// Automatically plays MP3 files from any inserted USB flash drive.
+// Uses AVFoundation for audio — no external player required.
+// Runs as a macOS menu bar (status bar) application.
+//
+// Build:
+//   swiftc USBGroove.swift -o USBGroove -framework AVFoundation \
+//       -framework DiskArbitration -framework AppKit
+// =============================================================================
+
+import AppKit
+import AVFoundation
+import DiskArbitration
+
+// MARK: - App Delegate
+
+class AppDelegate: NSObject, NSApplicationDelegate, AVAudioPlayerDelegate {
+
+    private var statusItem: NSStatusItem!
+    private var player: AVAudioPlayer?
+    private var playlist: [URL] = []
+    private var currentTrack: Int = -1
+    private var shuffleOn: Bool = false
+    private var daSession: DASession?
+    private var mountedUSBPaths: Set<String> = []
+
+    // MARK: - Lifecycle
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        setupStatusItem()
+        setupDiskArbitration()
+        log("USB Groove started. Waiting for USB drives...")
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        stopPlayback()
+        if let session = daSession {
+            DASessionSetDispatchQueue(session, nil)
+        }
+    }
+
+    // MARK: - Menu Bar
+
+    private func setupStatusItem() {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        if let button = statusItem.button {
+            button.image = NSImage(systemSymbolName: "music.note", accessibilityDescription: "USB Groove")
+            button.toolTip = "USB Groove — waiting for USB drive"
+        }
+        updateMenu()
+    }
+
+    private func updateMenu() {
+        let menu = NSMenu()
+
+        if currentTrack >= 0 && !playlist.isEmpty {
+            let title = trackTitle(currentTrack)
+            let state = (player?.isPlaying == true) ? "Playing" : "Paused"
+            let header = "\(state): \(title)  [\(currentTrack + 1)/\(playlist.count)]"
+            let headerItem = NSMenuItem(title: header, action: nil, keyEquivalent: "")
+            headerItem.isEnabled = false
+            menu.addItem(headerItem)
+            menu.addItem(NSMenuItem.separator())
+        }
+
+        let playPauseTitle = (player?.isPlaying == true) ? "Pause" : "Resume"
+        let playPause = NSMenuItem(title: playPauseTitle, action: #selector(togglePlayPause), keyEquivalent: "p")
+        playPause.target = self
+        playPause.isEnabled = currentTrack >= 0
+        menu.addItem(playPause)
+
+        let prev = NSMenuItem(title: "Previous Track", action: #selector(prevTrack), keyEquivalent: "[")
+        prev.target = self
+        prev.isEnabled = currentTrack > 0
+        menu.addItem(prev)
+
+        let next = NSMenuItem(title: "Next Track", action: #selector(nextTrack), keyEquivalent: "]")
+        next.target = self
+        next.isEnabled = currentTrack >= 0 && currentTrack < playlist.count - 1
+        menu.addItem(next)
+
+        let stop = NSMenuItem(title: "Stop", action: #selector(stopAction), keyEquivalent: "s")
+        stop.target = self
+        stop.isEnabled = currentTrack >= 0
+        menu.addItem(stop)
+
+        menu.addItem(NSMenuItem.separator())
+
+        let shuffle = NSMenuItem(title: "Shuffle", action: #selector(toggleShuffle), keyEquivalent: "")
+        shuffle.target = self
+        shuffle.state = shuffleOn ? .on : .off
+        menu.addItem(shuffle)
+
+        menu.addItem(NSMenuItem.separator())
+
+        let about = NSMenuItem(title: "About USB Groove", action: #selector(showAbout), keyEquivalent: "")
+        about.target = self
+        menu.addItem(about)
+
+        let quit = NSMenuItem(title: "Quit", action: #selector(quitApp), keyEquivalent: "q")
+        quit.target = self
+        menu.addItem(quit)
+
+        statusItem.menu = menu
+    }
+
+    private func updateTooltip() {
+        if currentTrack >= 0 && !playlist.isEmpty {
+            let title = trackTitle(currentTrack)
+            let state = (player?.isPlaying == true) ? "" : " (paused)"
+            statusItem.button?.toolTip = "\(title) [\(currentTrack + 1)/\(playlist.count)]\(state)"
+        } else {
+            statusItem.button?.toolTip = "USB Groove — idle"
+        }
+    }
+
+    private func showNotification(title: String, body: String) {
+        let notification = NSUserNotification()
+        notification.title = title
+        notification.informativeText = body
+        notification.soundName = nil
+        NSUserNotificationCenter.default.deliver(notification)
+    }
+
+    // MARK: - Menu Actions
+
+    @objc private func togglePlayPause() {
+        guard currentTrack >= 0, let p = player else { return }
+        if p.isPlaying {
+            p.pause()
+            log("Paused.")
+        } else {
+            p.play()
+            log("Resumed.")
+        }
+        updateTooltip()
+        updateMenu()
+    }
+
+    @objc private func nextTrack() {
+        guard !playlist.isEmpty else { return }
+        let next = currentTrack + 1
+        if next < playlist.count {
+            playTrack(next)
+        }
+    }
+
+    @objc private func prevTrack() {
+        guard !playlist.isEmpty else { return }
+        let prev = currentTrack - 1
+        if prev >= 0 {
+            playTrack(prev)
+        }
+    }
+
+    @objc private func stopAction() {
+        stopPlayback()
+    }
+
+    @objc private func toggleShuffle() {
+        shuffleOn.toggle()
+        log(shuffleOn ? "Shuffle ON." : "Shuffle OFF.")
+        updateMenu()
+    }
+
+    @objc private func showAbout() {
+        let alert = NSAlert()
+        alert.messageText = "USB Groove"
+        alert.informativeText = """
+            macOS Menu Bar App
+
+            Plays MP3 files automatically from any USB drive.
+            No media player required — built-in audio engine.
+
+            Click menu bar icon for controls.
+            """
+        alert.alertStyle = .informational
+        alert.runModal()
+    }
+
+    @objc private func quitApp() {
+        stopPlayback()
+        NSApplication.shared.terminate(nil)
+    }
+
+    // MARK: - Disk Arbitration (USB Detection)
+
+    private func setupDiskArbitration() {
+        guard let session = DASessionCreate(kCFAllocatorDefault) else {
+            log("Failed to create DiskArbitration session.")
+            return
+        }
+        daSession = session
+
+        let mountCallback: DADiskMountApprovalCallback = { disk, context in
+            return nil  // approve all mounts
+        }
+        _ = mountCallback  // suppress unused warning
+
+        // Watch for volume mounts via NSWorkspace
+        let center = NSWorkspace.shared.notificationCenter
+        center.addObserver(
+            self,
+            selector: #selector(volumeDidMount(_:)),
+            name: NSWorkspace.didMountNotification,
+            object: nil
+        )
+        center.addObserver(
+            self,
+            selector: #selector(volumeDidUnmount(_:)),
+            name: NSWorkspace.didUnmountNotification,
+            object: nil
+        )
+
+        log("Disk monitoring active.")
+    }
+
+    @objc private func volumeDidMount(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let volumePath = userInfo[NSWorkspace.volumeURLUserInfoKey] as? URL else {
+            return
+        }
+
+        let path = volumePath.path
+
+        // Check if this is a removable/external volume
+        guard isExternalVolume(path) else {
+            log("Volume \(path) is not external, skipping.")
+            return
+        }
+
+        log("USB drive detected: \(path)")
+        mountedUSBPaths.insert(path)
+
+        // Small delay to let filesystem settle
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+            self?.onDriveInserted(path: path)
+        }
+    }
+
+    @objc private func volumeDidUnmount(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let volumePath = userInfo[NSWorkspace.volumeURLUserInfoKey] as? URL else {
+            return
+        }
+
+        let path = volumePath.path
+        if mountedUSBPaths.remove(path) != nil {
+            log("USB drive removed: \(path)")
+            // Stop playback if we were playing from this drive
+            if currentTrack >= 0, !playlist.isEmpty,
+               playlist[currentTrack].path.hasPrefix(path) {
+                stopPlayback()
+                showNotification(title: "USB Groove", body: "USB drive removed — playback stopped.")
+            }
+        }
+    }
+
+    private func isExternalVolume(_ path: String) -> Bool {
+        let url = URL(fileURLWithPath: path)
+        do {
+            let values = try url.resourceValues(forKeys: [
+                .volumeIsRemovableKey,
+                .volumeIsEjectableKey,
+                .volumeIsInternalKey
+            ])
+            let isRemovable = values.volumeIsRemovable ?? false
+            let isEjectable = values.volumeIsEjectable ?? false
+            let isInternal = values.volumeIsInternal ?? true
+            return (isRemovable || isEjectable || !isInternal)
+        } catch {
+            return false
+        }
+    }
+
+    // MARK: - Drive Handler
+
+    private func onDriveInserted(path: String) {
+        let mp3s = scanForMp3s(rootPath: path)
+        if mp3s.isEmpty {
+            let msg = "No MP3 files found on \(URL(fileURLWithPath: path).lastPathComponent)"
+            showNotification(title: "USB Groove", body: msg)
+            log(msg)
+            return
+        }
+
+        let volumeName = URL(fileURLWithPath: path).lastPathComponent
+        let msg = "Found \(mp3s.count) MP3 file(s) on \(volumeName) — starting playback."
+        showNotification(title: "USB Groove", body: msg)
+        log(msg)
+
+        startPlaylist(mp3s)
+    }
+
+    // MARK: - MP3 Scanner
+
+    private func scanForMp3s(rootPath: String) -> [URL] {
+        let rootURL = URL(fileURLWithPath: rootPath)
+        let fm = FileManager.default
+        var results: [URL] = []
+
+        guard let enumerator = fm.enumerator(
+            at: rootURL,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles, .skipsPackageDescendants]
+        ) else {
+            return results
+        }
+
+        for case let fileURL as URL in enumerator {
+            if fileURL.pathExtension.lowercased() == "mp3" {
+                results.append(fileURL)
+            }
+        }
+
+        results.sort { $0.path < $1.path }
+        return results
+    }
+
+    // MARK: - Playback Engine (AVFoundation)
+
+    private func startPlaylist(_ tracks: [URL]) {
+        stopPlayback()
+        playlist = tracks
+
+        if shuffleOn {
+            playlist.shuffle()
+        }
+
+        playTrack(0)
+    }
+
+    private func playTrack(_ index: Int) {
+        guard index >= 0 && index < playlist.count else { return }
+
+        player?.stop()
+        player = nil
+
+        do {
+            player = try AVAudioPlayer(contentsOf: playlist[index])
+            player?.delegate = self
+            player?.play()
+
+            currentTrack = index
+            updateTooltip()
+            updateMenu()
+
+            log("Playing [\(index + 1)/\(playlist.count)]: \(playlist[index].path)")
+        } catch {
+            log("Playback error: \(error.localizedDescription) — \(playlist[index].path)")
+            // Skip bad file
+            let next = index + 1
+            if next < playlist.count {
+                playTrack(next)
+            }
+        }
+    }
+
+    private func stopPlayback() {
+        player?.stop()
+        player = nil
+        playlist.removeAll()
+        currentTrack = -1
+        updateTooltip()
+        updateMenu()
+        log("Playback stopped.")
+    }
+
+    // MARK: - AVAudioPlayerDelegate
+
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        guard flag, currentTrack >= 0 else { return }
+
+        let next = currentTrack + 1
+        if next < playlist.count {
+            playTrack(next)
+        } else {
+            currentTrack = -1
+            self.player = nil
+            updateTooltip()
+            updateMenu()
+            showNotification(title: "USB Groove", body: "Playlist finished.")
+            log("Playlist finished.")
+        }
+    }
+
+    // MARK: - Utility
+
+    private func trackTitle(_ index: Int) -> String {
+        guard index >= 0 && index < playlist.count else { return "(none)" }
+        var name = playlist[index].deletingPathExtension().lastPathComponent
+        if name.count > 60 {
+            name = String(name.prefix(57)) + "..."
+        }
+        return name
+    }
+
+    private func log(_ msg: String) {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        let timestamp = formatter.string(from: Date())
+        let logLine = "[\(timestamp)] \(msg)\n"
+
+        let logPath = NSTemporaryDirectory() + "USBGroove.log"
+        if let handle = FileHandle(forWritingAtPath: logPath) {
+            handle.seekToEndOfFile()
+            handle.write(logLine.data(using: .utf8) ?? Data())
+            handle.closeFile()
+        } else {
+            FileManager.default.createFile(atPath: logPath, contents: logLine.data(using: .utf8))
+        }
+
+        #if DEBUG
+        print(logLine, terminator: "")
+        #endif
+    }
+}
+
+// MARK: - Main
+
+let app = NSApplication.shared
+app.setActivationPolicy(.accessory)  // menu bar only, no dock icon
+let delegate = AppDelegate()
+app.delegate = delegate
+app.run()


### PR DESCRIPTION
- Add native Swift macOS menu bar app using AVFoundation and DiskArbitration
- Update build workflow to build both Windows and macOS, attach both to releases
- Add Homebrew cask formula for macOS distribution
- Update README to cover both platforms

https://claude.ai/code/session_01UbDL6Yek9BrYz4PskjYTDM

## Description
<!-- Brief description of the changes made -->

## Related Issue
<!-- Link to related issue if applicable (e.g., #123) -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Testing Performed
<!-- Describe testing done to verify changes -->

## Checklist
- [ ] Code compiles cleanly
- [ ] Tested on Windows
- [ ] Updated documentation if needed
