### PR TITLE
Fix macOS CI: use venv for Pillow install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,8 +75,9 @@ jobs:
         run: |
           mkdir -p AppIcon.iconset
           # Use the 256px icon as base and resize for all iconset slots
-          pip3 install Pillow
-          python3 -c "
+          python3 -m venv .venv
+          .venv/bin/pip install Pillow
+          .venv/bin/python3 -c "
           from PIL import Image
           src = Image.open('icons/app_256.png')
           sizes = {


### PR DESCRIPTION
macOS runners now block bare pip3 install (PEP 668). Use a venv instead.