### PR TITLE
feat: auto-submit winget package on new releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
 
     outputs:
       tag: ${{ steps.version.outputs.tag }}
+      version: ${{ steps.version.outputs.number }}
 
   build-macos:
     runs-on: macos-latest
@@ -186,3 +187,14 @@ jobs:
             USBGroove-macOS.zip
           draft: false
           prerelease: false
+
+      - name: Update winget package
+        if: env.WINGET_PAT != ''
+        env:
+          WINGET_PAT: ${{ secrets.WINGET_PAT }}
+        uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: michaelnoergaard.USBGroove
+          version: ${{ needs.build-windows.outputs.version }}
+          installers-regex: 'USBGroove\.exe$'
+          token: ${{ secrets.WINGET_PAT }}

--- a/winget/michaelnoergaard.USBGroove.installer.yaml
+++ b/winget/michaelnoergaard.USBGroove.installer.yaml
@@ -1,14 +1,14 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: michaelnoergaard.USBGroove
-PackageVersion: "1.0"
+PackageVersion: "1.6"
 MinimumOSVersion: 10.0.17763.0
 InstallerType: portable
 Commands:
   - USBGroove
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/michaelnoergaard/USB-Groove/releases/download/v1.0/USBGroove.exe
-    InstallerSha256: <REPLACE_WITH_SHA256_HASH>
+    InstallerUrl: https://github.com/michaelnoergaard/USB-Groove/releases/download/v1.6/USBGroove.exe
+    InstallerSha256: 39F554B1AF7107F1681F193FF895107A9FFCB44236CA910963EFDD62BE9241D5
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/winget/michaelnoergaard.USBGroove.locale.en-US.yaml
+++ b/winget/michaelnoergaard.USBGroove.locale.en-US.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: michaelnoergaard.USBGroove
-PackageVersion: "1.0"
+PackageVersion: "1.6"
 PackageLocale: en-US
 Publisher: michaelnoergaard
 PublisherUrl: https://github.com/michaelnoergaard

--- a/winget/michaelnoergaard.USBGroove.yaml
+++ b/winget/michaelnoergaard.USBGroove.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: michaelnoergaard.USBGroove
-PackageVersion: "1.0"
+PackageVersion: "1.6"
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.6.0


### PR DESCRIPTION
## Summary
- Add `winget-releaser` action to automatically submit a PR to `microsoft/winget-pkgs` on every new release
- Fix winget manifests: update version from 1.0 to 1.6, correct download URL, and add proper SHA256 hash
- Gated on `WINGET_PAT` secret — silently skips if not configured

## Setup required
Add a GitHub PAT as a repository secret named `WINGET_PAT` with `public_repositories` access.

## Test plan
- [x] Validated manifest locally with `winget validate --manifest .\winget\`
- [x] Tested install locally with `winget install --manifest .\winget\`
- [ ] Verify `WINGET_PAT` secret is added to repo settings
- [ ] Verify winget-releaser step runs on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)