### PR TITLE
fix: don't fail build when winget package doesn't exist yet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,6 +189,7 @@ jobs:
           prerelease: false
 
       - name: Update winget package
+        continue-on-error: true
         if: env.WINGET_PAT != ''
         env:
           WINGET_PAT: ${{ secrets.WINGET_PAT }}


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to the winget-releaser step so it doesn't fail the entire build when the package isn't yet in microsoft/winget-pkgs

## Test plan
- [ ] Verify build passes even if winget update step fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)