### PR TITLE
fix: add forward declarations for autorun functions

### DIFF
--- a/USBAutoPlayer.cpp
+++ b/USBAutoPlayer.cpp
@@ -85,6 +85,8 @@ void MciClose();
 void PlayTrack(int index);
 void StopPlayback();
 void PauseResume();
+bool IsAutorunEnabled();
+void ToggleAutorun();
 void NextTrack();
 void PrevTrack();
 std::wstring TrackTitle(int index);


### PR DESCRIPTION
## Summary
- Add missing forward declarations for `IsAutorunEnabled()` and `ToggleAutorun()` which are called in `WndProc` but defined later in the file

## Test plan
- [ ] Verify Windows build succeeds in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)