### PR TITLE
fix: remove unused disk mount callback

### DIFF
--- a/macos/USBGroove.swift
+++ b/macos/USBGroove.swift
@@ -320,11 +320,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, AVAudioPlayerDelegate {
         daSession = session
         DASessionSetDispatchQueue(session, DispatchQueue.main)
 
-        let mountCallback: DADiskMountApprovalCallback = { disk, context in
-            return nil  // approve all mounts
-        }
-        _ = mountCallback  // suppress unused warning
-
         // Watch for volume mounts via NSWorkspace
         let center = NSWorkspace.shared.notificationCenter
         center.addObserver(


### PR DESCRIPTION
## Description
Removes the unused `DADiskMountApprovalCallback` declaration from the macOS Disk Arbitration setup. The callback was never registered, so it only made the code read like mount approval behavior existed when USB detection is actually handled by `NSWorkspace` notifications.

## Related Issue
Fixes #46

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Testing Performed
- `test -z "$(grep -n "mountCallback\|DADiskMountApprovalCallback" macos/USBGroove.swift)"`
- `swiftc macos/USBGroove.swift -o /tmp/usb-groove-46-build/USBGroove -framework AVFoundation -framework DiskArbitration -framework AppKit -O`
- `git diff --check`

The Swift compile still reports the existing macOS `NSUserNotification` deprecation warnings, unrelated to this change.

## Checklist
- [x] Code compiles cleanly
- [ ] Tested on Windows
- [ ] Updated documentation if needed